### PR TITLE
added bibentrysetfield test with 16 test cases.

### DIFF
--- a/jablib/src/test/java/org/jabref/model/entry/BibEntryGraphTest.java
+++ b/jablib/src/test/java/org/jabref/model/entry/BibEntryGraphTest.java
@@ -1,0 +1,78 @@
+package org.jabref.model.entry;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.FieldFactory;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.EntryType;
+import org.jabref.model.entry.types.IEEETranEntryType;
+import org.jabref.model.entry.types.StandardEntryType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+public class BibEntryGraphTest {
+
+    private Optional<?> invokeGetSourceField(String fieldName, EntryType targetType, EntryType sourceType) throws Exception {
+        Field field = FieldFactory.parseField(fieldName);
+        Method method = BibEntry.class.getDeclaredMethod("getSourceField", org.jabref.model.entry.field.Field.class, EntryType.class, EntryType.class);
+        method.setAccessible(true);
+        BibEntry entry = new BibEntry(); // instance needed to call method
+        return (Optional<?>) method.invoke(entry, field, targetType, sourceType);
+    }
+
+    @Test
+    public void testT1_forbiddenField_IDS_returnsEmpty() throws Exception {
+        assertTrue(invokeGetSourceField("ids", StandardEntryType.InBook, StandardEntryType.Book).isEmpty());
+    }
+
+    @Test
+    public void testT2_mvBookToInBook_author_returnsAuthor() throws Exception {
+        assertEquals(StandardField.AUTHOR, invokeGetSourceField("author", StandardEntryType.InBook, StandardEntryType.MvBook).orElse(null));
+    }
+
+    @Test
+    public void testT3_bookToBookInBook_bookAuthor_returnsAuthor() throws Exception {
+        assertEquals(StandardField.AUTHOR, invokeGetSourceField("bookauthor", StandardEntryType.BookInBook, StandardEntryType.Book).orElse(null));
+    }
+
+    @Test
+    public void testT4_mvBookToBook_maintitle_returnsTitle() throws Exception {
+        assertEquals(StandardField.TITLE, invokeGetSourceField("maintitle", StandardEntryType.Book, StandardEntryType.MvBook).orElse(null));
+    }
+
+    @Test
+    public void testT5_mvBookToBook_title_returnsEmpty() throws Exception {
+        assertTrue(invokeGetSourceField("title", StandardEntryType.Book, StandardEntryType.MvBook).isEmpty());
+    }
+
+    @Test
+    public void testT6_bookToBookInBook_booktitle_returnsTitle() throws Exception {
+        assertEquals(StandardField.TITLE, invokeGetSourceField("booktitle", StandardEntryType.BookInBook, StandardEntryType.Book).orElse(null));
+    }
+
+    @Test
+    public void testT7_mvBookToBook_shorttitle_returnsEmpty() throws Exception {
+        assertTrue(invokeGetSourceField("shorttitle", StandardEntryType.Book, StandardEntryType.MvBook).isEmpty());
+    }
+
+    @Test
+    public void testT8_periodicalToArticle_journaltitle_returnsTitle() throws Exception {
+        assertEquals(StandardField.TITLE, invokeGetSourceField("journaltitle", StandardEntryType.Article, IEEETranEntryType.Periodical).orElse(null));
+    }
+
+    @Test
+    public void testT9_bookToBookInBook_titleaddon_returnsEmpty() throws Exception {
+        assertTrue(invokeGetSourceField("titleaddon", StandardEntryType.BookInBook, StandardEntryType.Book).isEmpty());
+    }
+
+    @Test
+    public void testT10_unknownField_returnsOriginalField() throws Exception {
+        Field result = (Field) invokeGetSourceField("unknownfield", StandardEntryType.Article, StandardEntryType.MvBook).orElse(null);
+        assertNotNull(result);
+        assertEquals("unknownfield", result.getName());
+    }
+}

--- a/jablib/src/test/java/org/jabref/model/entry/BibEntrySetFieldTest.java
+++ b/jablib/src/test/java/org/jabref/model/entry/BibEntrySetFieldTest.java
@@ -1,0 +1,148 @@
+package org.jabref.model.entry;
+
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.FieldFactory;
+import org.jabref.model.entry.field.StandardField;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+public class BibEntrySetFieldTest {
+
+    // T1
+    @Test
+    public void testT1_validRequiredField_validValue() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.AUTHOR, "Smith, John");
+        assertEquals("Smith, John", entry.getField(StandardField.AUTHOR).orElse(null));
+    }
+
+    // T2
+    @Test
+    public void testT2_validRequiredField_malformedValue() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.YEAR, "202A"); // malformed year
+        assertEquals("202A", entry.getField(StandardField.YEAR).orElse(null));
+    }
+
+    // T3
+    @Test
+    public void testT3_validRequiredField_emptyValue() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.AUTHOR, "");
+        assertTrue(entry.getField(StandardField.AUTHOR).isEmpty());
+    }
+
+    // T4
+    @Test
+    public void testT4_validRequiredField_latexValue() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.AUTHOR, "\\alpha and \\beta");
+        assertEquals("\\alpha and \\beta", entry.getField(StandardField.AUTHOR).orElse(null));
+    }
+
+    // T5
+    @Test
+    public void testT5_validOptionalField_validValue() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.NOTE, "Some note");
+        assertEquals("Some note", entry.getField(StandardField.NOTE).orElse(null));
+    }
+
+    // T6
+    @Test
+    public void testT6_validOptionalField_malformedValue() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.NOTE, "202A");
+        assertEquals("202A", entry.getField(StandardField.NOTE).orElse(null));
+    }
+
+    // T7
+    @Test
+    public void testT7_validOptionalField_emptyValue() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.NOTE, "");
+        assertTrue(entry.getField(StandardField.NOTE).isEmpty());
+    }
+
+    // T8
+    @Test
+    public void testT8_validOptionalField_latexValue() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.NOTE, "\\alpha and \\beta");
+        assertEquals("\\alpha and \\beta", entry.getField(StandardField.NOTE).orElse(null));
+    }
+
+    // T9
+    @Test
+    public void testT9_invalidField_validValue() {
+        BibEntry entry = new BibEntry();
+        Field custom = FieldFactory.parseField("xyz");
+        entry.setField(custom, "Valid");
+        assertEquals("Valid", entry.getField(custom).orElse(null));
+    }
+
+    // T10
+    @Test
+    public void testT10_invalidField_malformedValue() {
+        BibEntry entry = new BibEntry();
+        Field custom = FieldFactory.parseField("xyz");
+        entry.setField(custom, "202A");
+        assertEquals("202A", entry.getField(custom).orElse(null));
+    }
+
+    // T11
+    @Test
+    public void testT11_invalidField_emptyValue() {
+        BibEntry entry = new BibEntry();
+        Field custom = FieldFactory.parseField("xyz");
+        entry.setField(custom, "");
+        assertTrue(entry.getField(custom).isEmpty());
+    }
+
+    // T12
+    @Test
+    public void testT12_invalidField_latexValue() {
+        BibEntry entry = new BibEntry();
+        Field custom = FieldFactory.parseField("xyz");
+        entry.setField(custom, "\\alpha");
+        assertEquals("\\alpha", entry.getField(custom).orElse(null));
+    }
+
+    // T13
+    @Test
+    public void testT13_nullField_validValue() {
+        BibEntry entry = new BibEntry();
+        assertThrows(NullPointerException.class, () -> {
+            entry.setField(null, "Smith, John");
+        });
+    }
+
+    // T14
+    @Test
+    public void testT14_nullField_malformedValue() {
+        BibEntry entry = new BibEntry();
+        assertThrows(NullPointerException.class, () -> {
+            entry.setField(null, "202A");
+        });
+    }
+
+    // T15
+    @Test
+    public void testT15_nullField_emptyValue() {
+        BibEntry entry = new BibEntry();
+        assertThrows(NullPointerException.class, () -> {
+            entry.setField(null, "");
+        });
+    }
+
+    // T16
+    @Test
+    public void testT16_nullField_latexValue() {
+        BibEntry entry = new BibEntry();
+        assertThrows(NullPointerException.class, () -> {
+            entry.setField(null, "\\alpha");
+        });
+    }
+}


### PR DESCRIPTION
Closes _____
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of Jabef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
